### PR TITLE
Add support for GNOME 40

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
+++ b/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
@@ -3,6 +3,6 @@
 "name": "Mpris Indicator Button",
 "description": "A full featured MPRIS indicator.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.38"],
+"shell-version": ["3.38", "40.beta", "40"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/"
 }


### PR DESCRIPTION
Your extension seems to work straight without any changes in GNOME 40. Tested with the GNOME 40.beta.

Please consider merging this.