### PR TITLE
Whitelist Squeezebox for Shuffle and LoopStatus props

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
@@ -1808,7 +1808,7 @@ const MprisProxyHandler = GObject.registerClass({
         // Otherwise they remain hidden since it's pointless to show widgets that don't do anything...
         // For the sake of UI symmetry if either Shuffle or Loopstatus works both buttons will be shown,
         // the button shown for whichever non-functional prop will just be non-reactive.
-        if (this._player_name === 'Headset') {
+        if (['Headset', 'Squeezebox remote control'].includes(this._player_name)) {
             // Headset has valid reasons for Shuffle and LoopStatus to be non-reactive initially upon interface creation.
             // https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/issues/35
             this._updateShuffle();

--- a/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
@@ -42,6 +42,10 @@ const METADATA_KEYS = [
     'mpris:trackid',
     'xesam:url'
 ];
+const SHUFFLE_LOOP_WHITELIST = [
+    'Headset',
+    'Squeezebox remote control',
+];
 
 const Node = Gio.DBusNodeInfo.new_for_xml(
 `<node>
@@ -1808,7 +1812,7 @@ const MprisProxyHandler = GObject.registerClass({
         // Otherwise they remain hidden since it's pointless to show widgets that don't do anything...
         // For the sake of UI symmetry if either Shuffle or Loopstatus works both buttons will be shown,
         // the button shown for whichever non-functional prop will just be non-reactive.
-        if (['Headset', 'Squeezebox remote control'].includes(this._player_name)) {
+        if (SHUFFLE_LOOP_WHITELIST.includes(this._player_name)) {
             // Headset has valid reasons for Shuffle and LoopStatus to be non-reactive initially upon interface creation.
             // https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/issues/35
             this._updateShuffle();


### PR DESCRIPTION
- The shuffle and loop statuses toggle back so quickly that a change of value is never signalled, meaning that these capabilities are not detected.
- Silently attempting to toggle the shuffle status is potentially disruptive here, since Squeezeboxes support two kinds of shuffle (by track and by album), but MPRIS doesn’t distinguish between the two.