### PR TITLE
Gtk.IconTheme.get_default() can be NULL. Make chained has_icon call (in _getIcon) more robust.

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/dbus.js
@@ -1915,7 +1915,7 @@ const MprisProxyHandler = GObject.registerClass({
 
     _getIcon(symbolic) {
         let iconName = symbolic ? `${this.app_id}-symbolic` : this.app_id;
-        return this.app_id && Gtk.IconTheme.get_default().has_icon(iconName) ? Gio.ThemedIcon.new(iconName) : null;
+        return this.app_id && (Gtk.IconTheme.get_default() ? Gtk.IconTheme.get_default().has_icon(iconName) : false) ? Gio.ThemedIcon.new(iconName) : null;
     }
 
     _getMimeTypeIcon() {


### PR DESCRIPTION
Fixing #60. `Gtk.IconTheme.get_default()` can return NULL and will break the extension. Add a check before the chained call to `.has_icon()`.

I'm open to suggestions if there's better JS syntax available for this case.

Shorter syntax would be Optional Chaning in JS, but it's marked "experimental". Not sure about the mozjs compatibility of older GNOME versions. -> https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Operators/Optional_chaining