### PR TITLE
Translations

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/extension.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/extension.js
@@ -23,15 +23,14 @@ const Panel = imports.ui.main.panel;
 
 const stockMpris = Panel.statusArea.dateMenu._messageList._mediaSection;
 const shouldShow = stockMpris._shouldShow;
+const extensionUtils = imports.misc.extensionUtils;
+const { MprisIndicatorButton } =
+    extensionUtils.getCurrentExtension().imports.widgets;
 
-const { MprisIndicatorButton } = imports.misc.extensionUtils.getCurrentExtension().imports.widgets;
-
-const ROLE = 'mprisindicatorbutton';
+const ROLE = "mprisindicatorbutton@JasonLG1979.github.io";
 
 function init(extensionMeta) {
-    let localeDir = extensionMeta.dir.get_child('locale');
-    let localePath = localeDir.query_exists(null) ? localeDir.get_path() : imports.misc.config.LOCALEDIR;
-    imports.gettext.bindtextdomain(ROLE, localePath);
+    extensionUtils.initTranslations(ROLE);
 }
 
 function enable() {

--- a/mprisindicatorbutton@JasonLG1979.github.io/translations.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/translations.js
@@ -18,82 +18,110 @@
  * If this extension breaks your desktop you get to keep all of the pieces...
  */
 
-const _ = imports.gettext.domain('mprisindicatorbutton').gettext;
+const _ = imports.gettext.domain(
+    "mprisindicatorbutton@JasonLG1979.github.io"
+).gettext;
 
 // TRANSLATORS: These are all of the translatable strings in this extension.
 // Any new translatable strings will be added to the end as to not break previous translations.
 var TRANSLATED = {
     // TRANSLATORS: Non proper noun part of the extension's name.
     // User visible string and used by accessibility software.
-    get ['Indicator Button']() {return _("Indicator Button");},
+    get ["Indicator Button"]() {
+        return _("Indicator Button");
+    },
 
     // TRANSLATORS: The section of the extension's menu
     // that contains media control buttons like shuffle, previous, play pause and so on.
     // Will be prepended with the player's name.
     // Non user visible string, used by accessibility software.
-    get ['Media Controls']() {return _("Media Controls");},
+    get ["Media Controls"]() {
+        return _("Media Controls");
+    },
 
     // TRANSLATORS: Button Name. Random playback order.
     // Should be very short, ideally one word. Do not add "button",
     // the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Shuffle']() {return _("Shuffle");},
+    get ["Shuffle"]() {
+        return _("Shuffle");
+    },
 
     // TRANSLATORS: Button Name. Skip back to the previous track.
     // Should be very short, ideally one word. Do not add "button",
     // the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Previous']() {return _("Previous");},
+    get ["Previous"]() {
+        return _("Previous");
+    },
 
     // TRANSLATORS: Button Name. Dual function start playback or pause playback.
     // Should be very short, ideally no more than two word but at least two words, to represent
     // the dual function. Do not add "button" the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Play Pause']() {return _("Play Pause");},
+    get ["Play Pause"]() {
+        return _("Play Pause");
+    },
 
     // TRANSLATORS: Button Name. Stop playback.
     // Should be very short, ideally one word. Do not add "button",
     // the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Stop']() {return _("Stop");},
+    get ["Stop"]() {
+        return _("Stop");
+    },
 
     // TRANSLATORS: Button Name. Skip forward to the next track.
     // Should be very short, ideally one word. Do not add "button",
     // the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Next']() {return _("Next");},
+    get ["Next"]() {
+        return _("Next");
+    },
 
     // TRANSLATORS: Button Name. Repeat the track or track list.
     // Should be very short, ideally one word. Do not add "button",
     // the name is what it does not what it is.
     // Non user visible string, used by accessibility software.
-    get ['Repeat']() {return _("Repeat");},
+    get ["Repeat"]() {
+        return _("Repeat");
+    },
 
     // TRANSLATORS: The section of the extension's menu that contains the volume control.
     // Will be prepended with the player's name and appended with the volume value.
     // Non user visible string, used by accessibility software.
-    get ['Volume']() {return _("Volume");},
+    get ["Volume"]() {
+        return _("Volume");
+    },
 
     // TRANSLATORS: The section of the extension's menu that contains the trackList menu.
     // TrackList is a list of tracks but not necessarily a playlist.
     // Do NOT translate this as "playlist".
     // Will be prepended with the player's name.
     // User visible string and used by accessibility software.
-    get ['TrackList']() {return _("TrackList");},
+    get ["TrackList"]() {
+        return _("TrackList");
+    },
 
     // TRANSLATORS: The section of the extension's menu that contains the playlists menu.
     // PlayLists is a list of playlists.
     // Will be prepended with the player's name.
     // User visible string and used by accessibility software.
-    get ['PlayLists']() {return _("PlayLists");},
+    get ["PlayLists"]() {
+        return _("PlayLists");
+    },
 
     // TRANSLATORS: An item in the Playlists menu.
     // Will be prepended with the player's name and appended with the playlist's name.
     // Non user visible string, used by accessibility software.
-    get ['PlayList Item']() {return _("PlayList Item");},
+    get ["PlayList Item"]() {
+        return _("PlayList Item");
+    },
 
     // TRANSLATORS: An item in the TrackList menu.
     // Will be prepended with the player's name and appended with the TrackList Item's info.
     // Non user visible string, used by accessibility software.
-    get ['TrackList Item']() {return _("TrackList Item");}
+    get ["TrackList Item"]() {
+        return _("TrackList Item");
+    },
 };

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,71 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-10-31 08:34+0100\n"
+"PO-Revision-Date: 2022-10-31 08:38+0100\n"
+"Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: translations.js:28
+msgid "Indicator Button"
+msgstr "Indikator Schaltfläche"
+
+#: translations.js:34
+msgid "Media Controls"
+msgstr "Mediensteuerung"
+
+#: translations.js:40
+msgid "Shuffle"
+msgstr "Zufallswiedergabe"
+
+#: translations.js:46
+msgid "Previous"
+msgstr "Verheriges"
+
+#: translations.js:52
+msgid "Play Pause"
+msgstr "Abspielen Pausieren"
+
+#: translations.js:58
+msgid "Stop"
+msgstr "Stop"
+
+#: translations.js:64
+msgid "Next"
+msgstr "Nächstes"
+
+#: translations.js:70
+msgid "Repeat"
+msgstr "Wiederholen"
+
+#: translations.js:75
+msgid "Volume"
+msgstr "Lautsärke"
+
+#: translations.js:82
+msgid "TrackList"
+msgstr "Titelliste"
+
+#: translations.js:88
+msgid "PlayLists"
+msgstr "Wiedergabeliste"
+
+#: translations.js:93
+msgid "PlayList Item"
+msgstr "Wiedergabelisteneintrag"
+
+#: translations.js:98
+msgid "TrackList Item"
+msgstr "Titellisteneintrag"

--- a/po/mprisindicatorbutton@JasonLG1979.github.io.pot
+++ b/po/mprisindicatorbutton@JasonLG1979.github.io.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-10-31 08:34+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: translations.js:28
+msgid "Indicator Button"
+msgstr ""
+
+#: translations.js:34
+msgid "Media Controls"
+msgstr ""
+
+#: translations.js:40
+msgid "Shuffle"
+msgstr ""
+
+#: translations.js:46
+msgid "Previous"
+msgstr ""
+
+#: translations.js:52
+msgid "Play Pause"
+msgstr ""
+
+#: translations.js:58
+msgid "Stop"
+msgstr ""
+
+#: translations.js:64
+msgid "Next"
+msgstr ""
+
+#: translations.js:70
+msgid "Repeat"
+msgstr ""
+
+#: translations.js:75
+msgid "Volume"
+msgstr ""
+
+#: translations.js:82
+msgid "TrackList"
+msgstr ""
+
+#: translations.js:88
+msgid "PlayLists"
+msgstr ""
+
+#: translations.js:93
+msgid "PlayList Item"
+msgstr ""
+
+#: translations.js:98
+msgid "TrackList Item"
+msgstr ""


### PR DESCRIPTION
I used the following guide:
https://gjs.guide/extensions/development/translations.html#marking-strings-for-translation
Could not test it as the extension does not work currently :(

to pack the extension with locale support run:
"gnome-extensions pack --podir=../po" inside the extensions folder (mprisindicatorbutton@JasonLG1979.github.io)
this will create a zip file with the locale structure