### PR TITLE
Add support for GNOME 43

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
+++ b/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
@@ -3,6 +3,6 @@
 "name": "Mpris Indicator Button",
 "description": "A full featured MPRIS indicator.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.38", "40", "41", "42"],
+"shell-version": ["3.38", "40", "41", "42","43"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/"
 }

--- a/mprisindicatorbutton@JasonLG1979.github.io/widgets.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/widgets.js
@@ -21,7 +21,6 @@
 // No translatable strings in this file.
 const { Atk, Clutter, Gio, GObject, St } = imports.gi;
 
-const { AggregateLayout } = imports.ui.panel;
 const { Button } = imports.ui.panelMenu;
 const { PopupBaseMenuItem, PopupSubMenuMenuItem, PopupMenuSection, PopupSeparatorMenuItem, Ornament} = imports.ui.popupMenu;
 const { Slider } = imports.ui.slider;
@@ -1632,3 +1631,33 @@ var MprisIndicatorButton = GObject.registerClass({
         return Clutter.EVENT_PROPAGATE;
     }
 });
+
+var AggregateLayout = GObject.registerClass(
+class AggregateLayout extends Clutter.BoxLayout {
+    _init(params = {}) {
+        params['orientation'] = Clutter.Orientation.VERTICAL;
+        super._init(params);
+
+        this._sizeChildren = [];
+    }
+
+    addSizeChild(actor) {
+        this._sizeChildren.push(actor);
+        this.layout_changed();
+    }
+
+    vfunc_get_preferred_width(container, forHeight) {
+        let themeNode = container.get_theme_node();
+        let minWidth = themeNode.get_min_width();
+        let natWidth = minWidth;
+
+        for (let i = 0; i < this._sizeChildren.length; i++) {
+            let child = this._sizeChildren[i];
+            let [childMin, childNat] = child.get_preferred_width(forHeight);
+            minWidth = Math.max(minWidth, childMin);
+            natWidth = Math.max(natWidth, childNat);
+        }
+        return [minWidth, natWidth];
+    }
+});
+


### PR DESCRIPTION
It simply adds the [removed code](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-42/js/ui/panel.js#L332) for `AggregateLayout` to `widgets.js`

This is a quick and simple fix for [my own testing purposes](https://github.com/Moon-0xff/gnome-mpris-label/issues/7), so don't expect much of it :P